### PR TITLE
Fixup Lenovo yoga slim7x

### DIFF
--- a/X1E80100-LENOVO-Yoga-Slim7x.m4
+++ b/X1E80100-LENOVO-Yoga-Slim7x.m4
@@ -14,18 +14,10 @@ include(`audioreach/tokens.m4')
 # | [WR_SH] -> [PCM DEC] -> [PCM CONV] -> [LOG]  |- Kcontrol
 # |______________________________________________|
 #
-dnl Playback MultiMedia1
-STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA1,
-	`S16_LE', 48000, 48000, 2, 4,
-	0x00004001, 0x00004001, 0x00006001, `110000')
 dnl Playback MultiMedia2
 STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA2,
 	`S16_LE', 48000, 48000, 2, 4,
 	0x00004002, 0x00004002, 0x00006010, `110000')
-dnl Capture MultiMedia3
-STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA3,
-	`S16_LE', 48000, 48000, 1, 2,
-	0x00004003, 0x00004003, 0x00006020, `110000')
 dnl Capture MultiMedia4
 STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA4,
 	`S16_LE', 48000, 48000, 1, 2,
@@ -55,13 +47,11 @@ DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `VA_CODEC_DMA_TX_
 	LPAIF_INTF_TYPE_VA, CODEC_INTF_IDX_TX0, 0, DATA_FORMAT_FIXED_POINT,
 	0x00004018, 0x00004018, 0x00006180)
 
-STREAM_DEVICE_PLAYBACK_MIXER(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_MIXER(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0'', ``MultiMedia2'')
 
-STREAM_DEVICE_PLAYBACK_ROUTE(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia2, stream1.logger1'')
 
 dnl STREAM_DEVICE_CAPTURE_MIXER(stream-index, kcontro1, kcontrol2... kcontrolN)
-STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA3, ``VA_CODEC_DMA_TX_0'' )
 STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA4, ``VA_CODEC_DMA_TX_0'' )
 dnl STREAM_DEVICE_CAPTURE_ROUTE(stream-index, mixer-name, route1, route2.. routeN)
-STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA3, ``MultiMedia3 Mixer'', ``VA_CODEC_DMA_TX_0, device110.logger1'')
 STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA4, ``MultiMedia4 Mixer'', ``VA_CODEC_DMA_TX_0, device110.logger1'')

--- a/X1E80100-LENOVO-Yoga-Slim7x.m4
+++ b/X1E80100-LENOVO-Yoga-Slim7x.m4
@@ -20,7 +20,7 @@ STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTI
 	0x00004002, 0x00004002, 0x00006010, `110000')
 dnl Capture MultiMedia4
 STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA4,
-	`S16_LE', 48000, 48000, 1, 2,
+	`S16_LE', 48000, 48000, 1, 4,
 	0x00004004, 0x00004004, 0x00006030, `110000')
 #
 #


### PR DESCRIPTION
1. Since Lenovo Yoga Slim7x does not have a headphone jack, it does not have wcd codec, as also visible from the upstream device tree. Drop leftover nodes from audioreach topology to get rid of the dmesg errors:

Before the fix:
```
[    8.537998]  MultiMedia1 Playback: ASoC: no backend DAIs enabled for MultiMedia1 Playback, possibly missing ALSA mixer-based routing or UCM profile
```
(Seems only 1 error is printed at the time. Removing MultiMedia1 endpoint results in error for MultiMedia3 being shown)

2. It appears there is typo in the number of microphones defined - in one place its 4, in one its 2. Fix to be 4 in all cases, like on CRD.

Both changes together are tested on the mentioned laptop. Upstream[ alsa-ucf-conf ](https://github.com/alsa-project/alsa-ucm-conf)was used. Together with a ~[device-tree change](https://lore.kernel.org/all/20250411155852.4238-1-alex.vinarskis@gmail.com/)~ [device-tree change](https://lore.kernel.org/all/20250412124956.20562-1-alex.vinarskis@gmail.com/) to enable microphones, I can confirm that:
* x4 speakers are working. L, R are mapped correctly
* Microphones are working. Though, it seems 2 microphones closer to the edges of screen are less sensitive/off, two middle ones are higher sensitivity. This is the case both before and after this patchset.
* No more audio related errors in dmesg