### PR TITLE
Update-QCS6490-RB3Gen2-tplg-name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(TPLGS
 	"X1E80100-LENOVO-Yoga-Slim7x\;X1E80100-LENOVO-Yoga-Slim7x\;qcom/x1e80100/LENOVO/83ED\;"
 	"QCM6490-IDP\;qcm6490-idp-snd-card\;qcom/qcm6490/qcm6490-idp\;"
 	"QCS6490-Radxa-Dragon-Q6A\;QCS6490-Radxa-Dragon-Q6A\;qcom/qcs6490/radxa/dragon-q6a\;"
-  "QCS6490-RB3Gen2\;qcs6490-rb3gen2-snd-card\;qcom/qcs6490/qcs6490-rb3gen2\;"
+	"QCS6490-RB3Gen2\;QCS6490-RB3Gen2\;qcom/qcs6490/qcs6490-rb3gen2\;"
   )
 
 add_custom_target(topologies ALL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(TPLGS
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-TUXEDO-Elite-14\;qcom/x1e80100\;"
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-Romulus\;qcom/x1e80100\;"
 	"X1E80100-LENOVO-Yoga-Slim7x\;X1E80100-LENOVO-Yoga-Slim7x\;qcom/x1e80100/LENOVO/83ED\;"
-	"QCM6490-IDP\;qcm6490-idp-snd-card\;qcom/qcm6490/qcm6490-idp\;"
+	"QCM6490-IDP\;QCM6490-IDP\;qcom/qcm6490/qcm6490-idp\;"
 	"QCS6490-Radxa-Dragon-Q6A\;QCS6490-Radxa-Dragon-Q6A\;qcom/qcs6490/radxa/dragon-q6a\;"
 	"QCS6490-RB3Gen2\;QCS6490-RB3Gen2\;qcom/qcs6490/qcs6490-rb3gen2\;"
   )


### PR DESCRIPTION
Rename the tplg file from qcs6490-rb3gen2-snd-card to QCS6490-RB3Gen2 and also rename the
topology file from qcm6490-idp-snd-card to QCM6490-IDP.

Removed inappropriate 'snd-card' suffix from topology name. Ensured topology name matches the soundcard name representing the board.