### PR TITLE
audioreach: x1e80100-tuxedo-elite-14: Add audio on DisplayPort/USB and HDMI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set(TPLGS
 	"X1E80100-CRD\;X1E80100-CRD\;qcom/x1e80100\;"
 	"X1E80100-CRD\;X1E80100-EVK\;qcom/x1e80100\;"
 	"X1E80100-CRD\;X1E001DE-DEVKIT\;qcom/x1e80100\;"
-	"X1E80100-CRD\;X1E80100-TUXEDO-Elite-14\;qcom/x1e80100\;"
+	"X1E80100-TUXEDO-Elite-14\;X1E80100-TUXEDO-Elite-14\;qcom/x1e80100\;"
 	"X1E80100-Dell-Latitude-7455\;X1E80100-Dell-Inspiron-14p-7441\;qcom/x1e80100/dell/inspiron-14-plus-7441\;"
 	"X1E80100-Dell-Latitude-7455\;X1E80100-Dell-Latitude-7455\;qcom/x1e80100/dell/latitude-7455\;"
 	"X1E80100-Dell-XPS-13-9345\;X1E80100-Dell-XPS-13-9345\;qcom/x1e80100/dell/xps13-9345\;"

--- a/X1E80100-TUXEDO-Elite-14.m4
+++ b/X1E80100-TUXEDO-Elite-14.m4
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright, Linaro Ltd, 2025
+include(`audioreach/audioreach.m4')
+include(`audioreach/stream-subgraph.m4')
+include(`audioreach/device-subgraph.m4')
+include(`util/route.m4')
+include(`util/mixer.m4')
+include(`audioreach/tokens.m4')
+#
+# Stream SubGraph  for MultiMedia Playback
+#
+#  ______________________________________________
+# |               Sub Graph 1                    |
+# | [WR_SH] -> [PCM DEC] -> [PCM CONV] -> [LOG]  |- Kcontrol
+# |______________________________________________|
+#
+dnl Playback MultiMedia1
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004001, 0x00004001, 0x00006001, `110000')
+dnl Playback MultiMedia2
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA2,
+	`S16_LE', 48000, 48000, 4, 4,
+	0x00004002, 0x00004002, 0x00006010, `110000')
+dnl Capture MultiMedia3
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA3,
+	`S16_LE', 48000, 48000, 1, 2,
+	0x00004003, 0x00004003, 0x00006020, `110000')
+dnl Capture MultiMedia4
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA4,
+	`S16_LE', 48000, 48000, 1, 4,
+	0x00004004, 0x00004004, 0x00006030, `110000')
+#
+#
+# Device SubGraph  for WSA RX0 Backend
+#
+#         ___________________
+#        |   Sub Graph 2     |
+# Mixer -| [LOG] -> [WSA EP] |
+#        |___________________|
+#
+dnl DEVICE_SG_ADD(stream, stream-dai-id, stream-index,
+dnl 	format, min-rate, max-rate, min-channels, max-channels,
+dnl	interface-type, interface-index, data-format,
+dnl	sg-iid-start, cont-iid-start, mod-iid-start
+dnl WSA Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-playback.m4, `WSA_CODEC_DMA_RX_0', WSA_CODEC_DMA_RX_0,
+	`S16_LE', 48000, 48000, 2, 4,
+	LPAIF_INTF_TYPE_WSA, CODEC_INTF_IDX_RX0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004005, 0x00004005, 0x00006050)
+dnl
+dnl WCDRX Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-playback.m4, `RX_CODEC_DMA_RX_0', RX_CODEC_DMA_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_RXTX, CODEC_INTF_IDX_RX0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004007, 0x00004007, 0x00006070)
+dnl
+dnl Display port0 (USB0) Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_0', DISPLAY_PORT_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_LPAIF, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004012, 0x00004012, 0x00006120, `DISPLAY_PORT_RX_0')
+dnl
+dnl Display port2 (HDMI) Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_2', DISPLAY_PORT_RX_2,
+	`S16_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_LPAIF, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004014, 0x00004014, 0x00006140, `DISPLAY_PORT_RX_2')
+dnl
+dnl VA Capture
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `VA_CODEC_DMA_TX_0', VA_CODEC_DMA_TX_0,
+	`S16_LE', 48000, 48000, 1, 4,
+	LPAIF_INTF_TYPE_VA, CODEC_INTF_IDX_TX0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004018, 0x00004018, 0x00006180)
+dnl
+dnl WCDTX Capture
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `TX_CODEC_DMA_TX_3', TX_CODEC_DMA_TX_3,
+	`S16_LE', 48000, 48000, 1, 2,
+	LPAIF_INTF_TYPE_RXTX, CODEC_INTF_IDX_TX3, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004019, 0x00004019, 0x00006190)
+
+STREAM_DEVICE_PLAYBACK_MIXER(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_MIXER(RX_CODEC_DMA_RX_0, ``RX_CODEC_DMA_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2'', ``MultiMedia1'', ``MultiMedia2'')
+
+STREAM_DEVICE_PLAYBACK_ROUTE(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(RX_CODEC_DMA_RX_0, ``RX_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+
+dnl STREAM_DEVICE_CAPTURE_MIXER(stream-index, kcontro1, kcontrol2... kcontrolN)
+STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA3, ``VA_CODEC_DMA_TX_0'',``TX_CODEC_DMA_TX_3'' )
+STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA4, ``VA_CODEC_DMA_TX_0'',``TX_CODEC_DMA_TX_3'' )
+dnl STREAM_DEVICE_CAPTURE_ROUTE(stream-index, mixer-name, route1, route2.. routeN)
+STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA3, ``MultiMedia3 Mixer'', ``VA_CODEC_DMA_TX_0, device110.logger1'', ``TX_CODEC_DMA_TX_3, device120.logger1'')
+STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA4, ``MultiMedia4 Mixer'', ``VA_CODEC_DMA_TX_0, device110.logger1'', ``TX_CODEC_DMA_TX_3, device120.logger1'')


### PR DESCRIPTION
Enabling DisplayPort0 (USB) and DisplayPort2 (HDMI) on TUXEDO Elite 14 Gen1.

Adding a different configuration file for TUXEDO Elite 14 Gen1 as CRD differs in the DisplayPort configuration. Everything else is similar.