### PR TITLE
CMakeLists.txt: stop excluding several platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,10 +42,7 @@ set(SKIPSYNC
 	"qcom/sc7180"
 	"qcom/sm8250"
 	# Not yet in linux-firmware
-	"qcom/qcm6490"
-	"qcom/qcs6490/radxa/dragon-q6a"
 	"qcom/sm8450"
-	"qcom/sm8750"
 	"qcom/x1e80100/ASUSTeK/vivobook-s15"
 	"qcom/x1e80100/ASUSTeK/zenbook-a14"
 	"qcom/x1e80100/LENOVO/21NH"
@@ -53,7 +50,6 @@ set(SKIPSYNC
 	"qcom/x1e80100/dell/latitude-7455"
 	"qcom/x1e80100/dell/xps13-9345"
 	"qcom/x1e80100/hp/omnibook-x14"
-	"qcom/x1e80100"
 )
 
 add_custom_target(topologies ALL)


### PR DESCRIPTION
Drop X1E80100, SM8750, QCM6490 and Dragon Q6A from the exclude list as those platforms got audio DSP firmware in the linux-firmware repo.