### PR TITLE
audioreach: qcs6490: add Thundercomm RubikPi3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TPLGS
 	"QCM6490-IDP\;QCM6490-IDP\;qcom/qcm6490\;"
 	"QCS6490-Radxa-Dragon-Q6A\;QCS6490-Radxa-Dragon-Q6A\;qcom/qcs6490/radxa/dragon-q6a\;"
 	"QCS6490-RB3Gen2\;QCS6490-RB3Gen2\;qcom/qcs6490\;"
+	"QCS6490-Thundercomm-RubikPi3\;QCS6490-Thundercomm-RubikPi3\;qcom/qcs6490/Thundercomm/RubikPi3\;"
   )
 
 # The list of directories to skip when synchronizing to linux-firmware

--- a/QCS6490-Thundercomm-RubikPi3.m4
+++ b/QCS6490-Thundercomm-RubikPi3.m4
@@ -1,0 +1,73 @@
+# Copyright, Linaro Ltd, 2023
+# SPDX-License-Identifier: BSD-3-Clause
+include(`audioreach/audioreach.m4')
+include(`audioreach/stream-subgraph.m4')
+include(`audioreach/device-subgraph.m4')
+include(`util/route.m4')
+include(`util/mixer.m4')
+include(`audioreach/tokens.m4')
+#
+# Stream SubGraph  for MultiMedia Playback
+#
+#  ______________________________________________
+# |               Sub Graph 1                    |
+# | [WR_SH] -> [PCM DEC] -> [PCM CONV] -> [LOG]  |- Kcontrol
+# |______________________________________________|
+#
+dnl Playback MultiMedia1
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004001, 0x00004001, 0x00006001, `110000')
+dnl
+dnl Playback MultiMedia2
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA2,
+	`S32_LE', 48000, 48000, 2, 2,
+	0x00004002, 0x00004002, 0x00006010, `110000')
+dnl
+dnl Capture MultiMedia3
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA3,
+	`S16_LE', 48000, 48000, 1, 2,
+	0x00004003, 0x00004003, 0x00006020, `110000')
+#
+#
+# Device SubGraph  for WSA RX0 Backend
+#
+#         ___________________
+#        |   Sub Graph 2     |
+# Mixer -| [LOG] -> [WSA EP] |
+#        |___________________|
+#
+dnl DEVICE_SG_ADD(stream, stream-dai-id, stream-index,
+dnl     format, min-rate, max-rate, min-channels, max-channels,
+dnl interface-type, interface-index, data-format,
+dnl sg-iid-start, cont-iid-start, mod-iid-start)
+
+dnl Primary MI2S Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-i2s-playback.m4, `Primary', PRIMARY_MI2S_RX,
+	`S16_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_LPAIF, I2S_INTF_TYPE_PRIMARY, SD_LINE_IDX_I2S_SD0, DATA_FORMAT_FIXED_POINT,
+	0x00004005, 0x00004005, 0x00006050, `PRIMARY_MI2S_RX')
+dnl
+dnl Quaternary MI2S Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-i2s-playback.m4, `Quaternary', QUATERNARY_MI2S_RX,
+	`S32_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_RXTX, I2S_INTF_TYPE_PRIMARY, SD_LINE_IDX_I2S_SD0, DATA_FORMAT_FIXED_POINT,
+	0x00004006, 0x00004006, 0x00006060, `QUATERNARY_MI2S_RX')
+dnl
+dnl Primary MI2S Capture
+DEVICE_SG_ADD(audioreach/subgraph-device-i2s-capture.m4, `Primary', PRIMARY_MI2S_TX,
+	`S16_LE', 48000, 48000, 1, 2,
+	LPAIF_INTF_TYPE_LPAIF, I2S_INTF_TYPE_PRIMARY, SD_LINE_IDX_I2S_SD1, DATA_FORMAT_FIXED_POINT,
+	0x00004007, 0x00004007, 0x00006070, `PRIMARY_MI2S_TX', `PRIMARY_MI2S_TX')
+dnl
+
+STREAM_DEVICE_PLAYBACK_MIXER(PRIMARY_MI2S_RX, ``PRIMARY_MI2S_RX'', ``MultiMedia1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(PRIMARY_MI2S_RX, ``PRIMARY_MI2S_RX Audio Mixer'', ``MultiMedia1, stream0.logger1'')
+
+STREAM_DEVICE_PLAYBACK_MIXER(QUATERNARY_MI2S_RX, ``QUATERNARY_MI2S_RX'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_ROUTE(QUATERNARY_MI2S_RX, ``QUATERNARY_MI2S_RX Audio Mixer'', ``MultiMedia2, stream1.logger1'')
+
+dnl STREAM_DEVICE_CAPTURE_MIXER(stream-index, kcontro1, kcontrol2... kcontrolN)
+STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA3, ``PRIMARY_MI2S_TX'')
+dnl STREAM_DEVICE_CAPTURE_ROUTE(stream-index, mixer-name, route1, route2.. routeN)
+STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA3, ``MultiMedia3 Mixer'', ``PRIMARY_MI2S_TX, device17.logger1'')


### PR DESCRIPTION
RUBIK Pi 3 (https://rubikpi.ai/), a lightweight development board based on
Qualcomm Dragonwing™ QCS6490 platform, is the first Pi built on Qualcomm
AI platforms for developers.


Full specs:
* Headphone jack using ES8316 codec.
* Onboard DSI to HDMI bridge, using Lontium LT9611, supports HDMI OUT audio.
* The TERTIARY_MI2S can be used via a 40-pin GPIO connector (unused by default).

The kernel device tree going to be upstreamed soon.