### PR TITLE
Add initial   topology for QCS6490 RB3Gen2 Industrial Mezz

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ set(TPLGS
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-Romulus\;qcom/x1e80100\;"
 	"X1E80100-LENOVO-Yoga-Slim7x\;X1E80100-LENOVO-Yoga-Slim7x\;qcom/x1e80100/LENOVO/83ED\;"
 	"QCM6490-IDP\;QCM6490-IDP\;qcom/qcm6490\;"
+	"QCM6490-IDP\;QCS6490-RB3Gen2-Industrial-Mezz\;qcom/qcs6490\;"
 	"QCS6490-Radxa-Dragon-Q6A\;QCS6490-Radxa-Dragon-Q6A\;qcom/qcs6490/radxa/dragon-q6a\;"
 	"QCS6490-RB3Gen2\;QCS6490-RB3Gen2\;qcom/qcs6490\;"
 	"QCS6490-Thundercomm-RubikPi3\;QCS6490-Thundercomm-RubikPi3\;qcom/qcs6490/Thundercomm/RubikPi3\;"


### PR DESCRIPTION
Add topology support for QCS6490 RB3Gen2 Industrial Mezzanine. Reuse qcm6490-idp topology as the audio hardware specification is identical.

QCS6490-RB3Gen2-Industrial-Mezz supports:

WSA Playback
VA Capture
WCD playback
WCD Capture