### PR TITLE
qcom: x1e-t14s: add dedicated multimedia streams for DisplayPort

### DIFF
--- a/X1E80100-LENOVO-Thinkpad-T14s.m4
+++ b/X1E80100-LENOVO-Thinkpad-T14s.m4
@@ -30,6 +30,18 @@ dnl Capture MultiMedia4
 STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA4,
 	`S16_LE', 48000, 48000, 1, 2,
 	0x00004004, 0x00004004, 0x00006030, `110000')
+dnl Playback MultiMedia5 - for DisplayPort RX 0
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA5,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004005, 0x00004005, 0x00006040, `110000')
+dnl Playback MultiMedia6 - for DisplayPort RX 1
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA6,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004006, 0x00004006, 0x00006050, `110000')
+dnl Playback MultiMedia7 - for DisplayPort RX 2
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA7,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004007, 0x00004007, 0x00006060, `110000')
 #
 #
 # Device SubGraph  for WSA RX0 Backend
@@ -47,55 +59,57 @@ dnl WSA Playback
 DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-playback.m4, `WSA_CODEC_DMA_RX_0', WSA_CODEC_DMA_RX_0,
 	`S16_LE', 48000, 48000, 2, 2,
 	LPAIF_INTF_TYPE_WSA, CODEC_INTF_IDX_RX0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004005, 0x00004005, 0x00006050)
+	0x00004008, 0x00004008, 0x00006070)
 dnl
 dnl WCDRX Playback
 DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-playback.m4, `RX_CODEC_DMA_RX_0', RX_CODEC_DMA_RX_0,
 	`S16_LE', 48000, 48000, 2, 2,
 	LPAIF_INTF_TYPE_RXTX, CODEC_INTF_IDX_RX0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004007, 0x00004007, 0x00006070)
-dnl
-dnl Display port0 Playback
-DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_0', DISPLAY_PORT_RX_0,
-	`S16_LE', 48000, 48000, 2, 2,
-	LPAIF_INTF_TYPE_LPAIF, 0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004012, 0x00004012, 0x00006120, `DISPLAY_PORT_RX_0')
-dnl
-dnl Display port1 Playback
-DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_1', DISPLAY_PORT_RX_1,
-	`S16_LE', 48000, 48000, 2, 2,
-	LPAIF_INTF_TYPE_LPAIF, 0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004013, 0x00004013, 0x00006130, `DISPLAY_PORT_RX_1')
-dnl
-dnl Display port2/HDMI Playback
-DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_2', DISPLAY_PORT_RX_2,
-	`S16_LE', 48000, 48000, 2, 2,
-	LPAIF_INTF_TYPE_LPAIF, 0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004014, 0x00004014, 0x00006140, `DISPLAY_PORT_RX_2')
+	0x00004009, 0x00004009, 0x00006080)
 dnl
 dnl VA Capture
 DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `VA_CODEC_DMA_TX_0', VA_CODEC_DMA_TX_0,
 	`S16_LE', 48000, 48000, 1, 2,
 	LPAIF_INTF_TYPE_VA, CODEC_INTF_IDX_TX0, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004018, 0x00004018, 0x00006180)
+	0x0000400A, 0x0000400A, 0x00006090)
 dnl
 dnl WCDTX Capture
 DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `TX_CODEC_DMA_TX_3', TX_CODEC_DMA_TX_3,
 	`S16_LE', 48000, 48000, 1, 2,
 	LPAIF_INTF_TYPE_RXTX, CODEC_INTF_IDX_TX3, 0, DATA_FORMAT_FIXED_POINT,
-	0x00004019, 0x00004019, 0x00006190)
+	0x0000400B, 0x0000400B, 0x000060A0)
+dnl
+dnl Display port0 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_0', DISPLAY_PORT_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x0000400C, 0x0000400C, 0x000060B0, `DISPLAY_PORT_RX_0')
+dnl
+dnl Display port1 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_1', DISPLAY_PORT_RX_1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x0000400D, 0x0000400D, 0x000060C0, `DISPLAY_PORT_RX_1')
+dnl
+dnl Display port2 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_2', DISPLAY_PORT_RX_2,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x0000400E, 0x0000400E, 0x000060D0, `DISPLAY_PORT_RX_2')
+dnl
 
 STREAM_DEVICE_PLAYBACK_MIXER(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
 STREAM_DEVICE_PLAYBACK_MIXER(RX_CODEC_DMA_RX_0, ``RX_CODEC_DMA_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
-STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0'', ``MultiMedia1'', ``MultiMedia2'')
-STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1'', ``MultiMedia1'', ``MultiMedia2'')
-STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2'', ``MultiMedia1'', ``MultiMedia2'')
+dnl DisplayPort mixers - dedicated MultiMedia5 .. MultiMedia7
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0'', ``MultiMedia5'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1'', ``MultiMedia6'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2'', ``MultiMedia7'')
 
 STREAM_DEVICE_PLAYBACK_ROUTE(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
 STREAM_DEVICE_PLAYBACK_ROUTE(RX_CODEC_DMA_RX_0, ``RX_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
-STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
-STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
-STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2 Audio Mixer'', ``MultiMedia1, stream0.logger1'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0 Audio Mixer'', ``MultiMedia5, stream4.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1 Audio Mixer'', ``MultiMedia6, stream5.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2 Audio Mixer'', ``MultiMedia7, stream6.logger1'')
 
 dnl STREAM_DEVICE_CAPTURE_MIXER(stream-index, kcontro1, kcontrol2... kcontrolN)
 STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA3, ``VA_CODEC_DMA_TX_0'',``TX_CODEC_DMA_TX_3'' )


### PR DESCRIPTION
Add MM5 .. MM7 as dedicated frontend DAIs for DisplayPort RX 0 .. RX 2 respectively, instead of sharing MM1/MM2 with speaker/headphone playback.

Update device subgraph instance IDs to avoid conflicts with the newly added MM5 .. MM7 stream subgraphs.
Renumbering/Cleanup of indexes.

Copied in the spirit of ebbbfae587284f0497a8503679c76dbdf15ee3ab
  ASoC: qcom: x1e80100-crd: add dedicated multimedia for DisplayPort (#56)
  Srinivas Kandagatla <srini@kernel.org>

The topology "works" with the "old" ucm config, too. The matching [ucm config](https://github.com/alsa-project/alsa-ucm-conf/pull/754) is a PR on the alsa-ucm-config repo. Since the topology is quite big, we're exceeding limits on the adsp driver. Needs a [patch](https://github.com/jglathe/linux_ms_dev_kit/tree/jg/q6-audioreach-hack), or you need the new Hexagon [patchset](https://lore.kernel.org/all/177514411128.51134.5760476545108119591.b4-ty@b4/) from @Srinivas-Kandagatla. 
I tested on the Lenovo T14s G6 and ThinkBook 16 G7 QOY with HDMI and type-c to HDMI adapters. 