### PR TITLE
qcom: sc8280xp: blackrock: topology for DisplayPorts only setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,8 @@ set(TPLGS
 	"SM8550-HDK\;SM8650-MTP\;qcom/sm8650\;"
 	"SM8550-HDK\;SM8750-MTP\;qcom/sm8750\;"
 	"SM8550-HDK\;SM8750-QRD\;qcom/sm8750\;"
-	"SC8280XP-LENOVO-X13S\;audioreach\;qcom/sc8280xp/LENOVO/21BX\;"
+	"SC8280XP-LENOVO-X13S\;SC8280XP-LENOVO-X13S\;qcom/sc8280xp/LENOVO/21BX\;"
+	"SC8280XP-MICROSOFT-BLACKROCK\;SC8280XP-MICROSOFT-BLACKROCK\;qcom/sc8280xp/microsoft/blackrock\;"
 	"Google-SC7180-WSA-Speakers-SEC-I2S-VA-DMIC-WCD-TX3\;Google-SC7180-WSA-Speakers-SEC-I2S-VA-DMIC-WCD-TX3\;qcom/sc7180\;"
 	"X1E80100-CRD\;X1E80100-CRD\;qcom/x1e80100\;"
 	"X1E80100-CRD\;X1E80100-EVK\;qcom/x1e80100\;"
@@ -48,6 +49,7 @@ set(SKIPSYNC
 	"qcom/sc7180"
 	"qcom/sm8250"
 	# Not yet in linux-firmware
+	"qcom/sc8280xp/microsoft/blackrock"
 	"qcom/x1e80100/LENOVO/21NH"
 )
 

--- a/SC8280XP-MICROSOFT-BLACKROCK.m4
+++ b/SC8280XP-MICROSOFT-BLACKROCK.m4
@@ -1,0 +1,69 @@
+# Copyright, Linaro Ltd, 2023
+# Copyright, Jens Glathe, 2026
+# SPDX-License-Identifier: BSD-3-Clause
+include(`audioreach/audioreach.m4')
+include(`audioreach/stream-subgraph.m4')
+include(`audioreach/device-subgraph.m4')
+include(`util/route.m4')
+include(`util/mixer.m4')
+include(`audioreach/tokens.m4')
+#
+# Stream SubGraph  for MultiMedia Playback
+# 
+#  ______________________________________________
+# |               Sub Graph 1                    |
+# | [WR_SH] -> [PCM DEC] -> [PCM CONV] -> [LOG]  |- Kcontrol
+# |______________________________________________|
+#
+dnl Playback MultiMedia1
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA1,
+	`S16_LE', 48000, 48000, 2, 2,	
+	0x00004001, 0x00004001, 0x00006001)
+dnl Playback MultiMedia2
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA2,
+	`S16_LE', 48000, 48000, 2, 2,	
+	0x00004002, 0x00004002, 0x00006010)
+dnl Playback MultiMedia3
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA3,
+	`S16_LE', 48000, 48000, 2, 2,	
+	0x00004003, 0x00004003, 0x00006020)
+
+#
+#
+# Device SubGraph  for WSA RX0 Backend
+# 
+#         ___________________
+#        |   Sub Graph 2     |
+# Mixer -| [LOG] -> [WSA EP] |
+#        |___________________|
+#
+dnl DEVICE_SG_ADD(stream, stream-dai-id, stream-index, 
+dnl 	format, min-rate, max-rate, min-channels, max-channels,
+dnl	interface-type, interface-index, data-format,
+dnl	sg-iid-start, cont-iid-start, mod-iid-start
+dnl Display port0 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_0', DISPLAY_PORT_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004004, 0x00004004, 0x00006030, `DISPLAY_PORT_RX_0')
+dnl
+dnl Display port1 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_1', DISPLAY_PORT_RX_1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004005, 0x00004005, 0x00006040, `DISPLAY_PORT_RX_1')
+dnl
+dnl Display port2 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_2', DISPLAY_PORT_RX_2,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004006, 0x00004006, 0x00006050, `DISPLAY_PORT_RX_2')
+dnl
+
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0'', ``MultiMedia1'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1'', ``MultiMedia2'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2'', ``MultiMedia3'')
+
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1 Audio Mixer'', ``MultiMedia2, stream1.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_2, ``DISPLAY_PORT_RX_2 Audio Mixer'', ``MultiMedia3, stream2.logger1'')


### PR DESCRIPTION
- Focused on DisplayPort audio only (no analog codec paths)
- 3x DisplayPort backends (DISPLAY_PORT_RX_0/1/2) for USB-C DP alt-mode + miniDP
- 3x playback streams (MultiMedia1/2/3) with volume control