### PR TITLE
x1e80100: Add Acer Swift 14 AI (SF14-11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set(TPLGS
 	"X1E80100-Dell-Latitude-7455\;X1E80100-Dell-Inspiron-14p-7441\;qcom/x1e80100/dell/inspiron-14-plus-7441\;"
 	"X1E80100-Dell-Latitude-7455\;X1E80100-Dell-Latitude-7455\;qcom/x1e80100/dell/latitude-7455\;"
 	"X1E80100-Dell-XPS-13-9345\;X1E80100-Dell-XPS-13-9345\;qcom/x1e80100/dell/xps13-9345\;"
+	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-ACER-SWIFT-14\;qcom/x1e80100\;"
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-ASUS-Vivobook-S15\;qcom/x1e80100/ASUSTeK/vivobook-s15\;"
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-ASUS-Vivobook-16\;qcom/x1e80100/ASUSTeK/vivobook-16\;"
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-ASUS-Zenbook-A14\;qcom/x1e80100/ASUSTeK/zenbook-a14\;"


### PR DESCRIPTION
Add support for the Acer Swift 14 AI (SF14-11), Snapdragon X1P-64100 laptop. Its audio hardware is identical to the Lenovo Thinkpad T14s: two SoundWire WSA speakers, a wcd938x headset codec on both SoundWire buses and VA DMICs, with identical audio-routing, DAI links and port mapping in the device tree.

Reuse the T14s topology under the name the machine driver asks for. The generated binary is byte-identical to X1E80100-Romulus-tplg.bin.