### PR TITLE
eliza: Reuse SM8550 topology for Eliza CQS EVK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TPLGS
 	"Qualcomm-RB5-WSA8815-Speakers-DMIC0-compress\;Qualcomm-RB5-WSA8815-Speakers-DMIC0-compress\;qcom/sm8250\;"
 	"SM8250-MTP-WCD9380-WSA8810-VA-DMIC\;SM8250-MTP-WCD9380-WSA8810-VA-DMIC\;qcom/sm8250\;"
 	"SM8450-HDK\;SM8450-HDK\;qcom/sm8450\;"
+	"SM8550-HDK\;eliza-cqs-evk\;qcom/eliza\;"
 	"SM8550-HDK\;Kaanapali-MTP\;qcom/kaanapali\;"
 	"SM8550-HDK\;SM8550-HDK\;qcom/sm8550\;"
 	"SM8550-HDK\;SM8550-QRD\;qcom/sm8550\;"


### PR DESCRIPTION
Add support for eliza-cqs-evk topology with reuse of SM8550.

Added support for eliza-cqs-evk topology by reusing the existing SM8550 configuration. Validated speaker playback and microphone recording functionality on eliza-cqs-evk hardware using the generated topology file.