### PR TITLE
audioreach: x1e80100: add topology for Microsoft Surface Pro 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TPLGS
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-LENOVO-ThinkBook-16\;qcom/x1e80100/LENOVO/21NH\;"
 	"X1E80100-LENOVO-Thinkpad-T14s\;X1E80100-Romulus\;qcom/x1e80100\;"
 	"X1P42100-Microsoft-Surface-Pro-12in\;X1P42100-Microsoft-Surface-Pro-12in\;qcom/x1e80100\;"
+	"X1E80100-Microsoft-Surface-Pro-11\;X1E80100-Microsoft-Surface-Pro-11\;qcom/x1e80100\;"
 	"X1E80100-LENOVO-Yoga-Slim7x\;X1E80100-LENOVO-Yoga-Slim7x\;qcom/x1e80100/LENOVO/83ED\;"
 	"QCM6490-IDP\;QCM6490-IDP\;qcom/qcm6490\;"
 	"QCM6490-IDP\;QCS6490-RB3Gen2-Industrial-Mezz\;qcom/qcs6490\;"

--- a/X1E80100-Microsoft-Surface-Pro-11.m4
+++ b/X1E80100-Microsoft-Surface-Pro-11.m4
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright, Linaro Ltd, 2025
+include(`audioreach/audioreach.m4')
+include(`audioreach/stream-subgraph.m4')
+include(`audioreach/device-subgraph.m4')
+include(`util/route.m4')
+include(`util/mixer.m4')
+include(`audioreach/tokens.m4')
+#
+# Stream SubGraph  for MultiMedia Playback
+#
+#  ______________________________________________
+# |               Sub Graph 1                    |
+# | [WR_SH] -> [PCM DEC] -> [PCM CONV] -> [LOG]  |- Kcontrol
+# |______________________________________________|
+#
+dnl Playback MultiMedia1
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004001, 0x00004001, 0x00006001, `110000')
+
+dnl Capture MultiMedia2
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-capture.m4, FRONTEND_DAI_MULTIMEDIA2,
+	`S16_LE', 48000, 48000, 1, 2,
+	0x00004002, 0x00004002, 0x00006010, `110000')
+
+dnl Playback MultiMedia3
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA3,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004003, 0x00004003, 0x00006020, `110000')
+
+dnl Playback MultiMedia4
+STREAM_SG_PCM_ADD(audioreach/subgraph-stream-vol-playback.m4, FRONTEND_DAI_MULTIMEDIA4,
+	`S16_LE', 48000, 48000, 2, 2,
+	0x00004004, 0x00004004, 0x00006030, `110000')
+#
+#
+# Device SubGraph  for WSA RX0 Backend
+#
+#         ___________________
+#        |   Sub Graph 2     |
+# Mixer -| [LOG] -> [WSA EP] |
+#        |___________________|
+#
+dnl DEVICE_SG_ADD(stream, stream-dai-id, stream-index,
+dnl 	format, min-rate, max-rate, min-channels, max-channels,
+dnl	interface-type, interface-index, data-format,
+dnl	sg-iid-start, cont-iid-start, mod-iid-start
+dnl WSA Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-playback.m4, `WSA_CODEC_DMA_RX_0', WSA_CODEC_DMA_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	LPAIF_INTF_TYPE_WSA, CODEC_INTF_IDX_RX0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004005, 0x00004005, 0x00006040)
+
+dnl DisplayPort 0 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_0', DISPLAY_PORT_RX_0,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004006, 0x00004006, 0x00006050, `DISPLAY_PORT_RX_0')
+
+dnl DisplayPort 1 Playback
+DEVICE_SG_ADD(audioreach/subgraph-device-display-port-playback.m4, `DISPLAY_PORT_RX_1', DISPLAY_PORT_RX_1,
+	`S16_LE', 48000, 48000, 2, 2,
+	0, 0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004007, 0x00004007, 0x00006060, `DISPLAY_PORT_RX_1')
+
+dnl VA Capture
+DEVICE_SG_ADD(audioreach/subgraph-device-codec-dma-capture.m4, `VA_CODEC_DMA_TX_0', VA_CODEC_DMA_TX_0,
+	`S16_LE', 48000, 48000, 1, 2,
+	LPAIF_INTF_TYPE_VA, CODEC_INTF_IDX_TX0, 0, DATA_FORMAT_FIXED_POINT,
+	0x00004008, 0x00004008, 0x00006070)
+
+STREAM_DEVICE_PLAYBACK_MIXER(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0'', ``MultiMedia1'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0'', ``MultiMedia3'')
+STREAM_DEVICE_PLAYBACK_MIXER(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1'', ``MultiMedia4'')
+
+STREAM_DEVICE_PLAYBACK_ROUTE(WSA_CODEC_DMA_RX_0, ``WSA_CODEC_DMA_RX_0 Audio Mixer'', ``MultiMedia1, stream0.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_0, ``DISPLAY_PORT_RX_0 Audio Mixer'', ``MultiMedia3, stream2.logger1'')
+STREAM_DEVICE_PLAYBACK_ROUTE(DISPLAY_PORT_RX_1, ``DISPLAY_PORT_RX_1 Audio Mixer'', ``MultiMedia4, stream3.logger1'')
+
+dnl STREAM_DEVICE_CAPTURE_MIXER(stream-index, kcontro1, kcontrol2... kcontrolN)
+STREAM_DEVICE_CAPTURE_MIXER(FRONTEND_DAI_MULTIMEDIA2, ``VA_CODEC_DMA_TX_0'' )
+
+dnl STREAM_DEVICE_CAPTURE_ROUTE(stream-index, mixer-name, route1, route2.. routeN)
+STREAM_DEVICE_CAPTURE_ROUTE(FRONTEND_DAI_MULTIMEDIA2, ``MultiMedia2 Mixer'', ``VA_CODEC_DMA_TX_0, device110.logger1'')


### PR DESCRIPTION
Add topology for Surface Pro 11: two WSA8845 speakers, a two-microphone VA DMIC array and two DisplayPort/HDMI outputs via the USB-C ports.

Devicetree changes for DP/HDMI submitted here:
https://lore.kernel.org/all/20260831-surface-pro-11-dp-audio-v1-1-fb9c0d3216b7@gmail.com/